### PR TITLE
Dependencies Fix

### DIFF
--- a/src/erlydtl/erlydtl_compiler.erl
+++ b/src/erlydtl/erlydtl_compiler.erl
@@ -471,9 +471,9 @@ merge_info(Info1, Info2) ->
 
 with_dependencies([], Args) ->
     Args;
-with_dependencies([H, T], Args) ->
-     with_dependencies(T, with_dependency(H, Args)).
-        
+with_dependencies([Dependency | Rest], Args) ->
+     with_dependencies(Rest, with_dependency(Dependency, Args)).
+
 with_dependency(FilePath, {{Ast, Info}, TreeWalker}) ->
     {{Ast, Info#ast_info{dependencies = [FilePath | Info#ast_info.dependencies]}}, TreeWalker}.
 


### PR DESCRIPTION
This fixes a bug that I ran into today--trying to compile module A that calls module B, which in turn includes module C, threw a compiler error.  I can provide an example if needed.
