### PR TITLE
Use lists module for erlydtl_runtime:find_value

### DIFF
--- a/src/erlydtl_runtime.erl
+++ b/src/erlydtl_runtime.erl
@@ -8,15 +8,20 @@ find_value(_, undefined) ->
     undefined;
 find_value(Key, Fun) when is_function(Fun, 1) ->
     Fun(Key);
-find_value(Key, L) when is_list(L) ->
-    case proplists:get_value(Key, L) of
-        undefined ->
-            case proplists:get_value(atom_to_list(Key), L) of
-                undefined ->
-                    proplists:get_value(list_to_binary(atom_to_list(Key)), L);
-                Val -> Val
-            end;
-        Val -> Val
+find_value(Key, L) when is_atom(Key), is_list(L) ->
+    case lists:keyfind(Key, 1, L) of
+        false           -> find_value(atom_to_list(Key), L);
+        {Key, Value}    -> Value
+    end;
+find_value(Key, L) when is_list(Key), is_list(L) ->
+    case lists:keyfind(Key, 1, L) of
+        false           -> find_value(list_to_binary(Key), L);
+        {Key, Value}    -> Value
+    end;
+find_value(Key, L) when is_binary(Key), is_list(L) ->
+    case lists:keyfind(Key, 1, L) of
+        false           -> undefined;
+        {Key, Value}    -> Value
     end;
 find_value(Key, {GBSize, GBData}) when is_integer(GBSize) ->
     case gb_trees:lookup(Key, {GBSize, GBData}) of


### PR DESCRIPTION
Use lists:keyfind over proplists:get_value for the find_value function in erlydtl_runtime. proplists is a pure-erlang library and is demonstrably slower than lists when searching for keys.
