### PR TITLE
is_float is a lot better than not is_integer...

### DIFF
--- a/src/filter_lib/erlydtl_dateformat.erl
+++ b/src/filter_lib/erlydtl_dateformat.erl
@@ -359,7 +359,7 @@ monthname(12) -> "december";
 monthname(_) -> "???".
 
 % Utility functions
-integer_to_list_zerofill(N) when not is_integer(N) ->
+integer_to_list_zerofill(N) when is_float(N) ->
     integer_to_list_zerofill(erlang:round(N));
 integer_to_list_zerofill(N) when N < 10 ->
     lists:flatten(io_lib:format("~2..0B", [N]));


### PR DESCRIPTION
Hi Evan,
Sorry for the embarrassingly small pull request, but when I went to bed after my last pull request got merged, it dawned on me that it was incredibly stupid to use "not is_integer" instead of "is_float".
