### PR TITLE
Only compile files with .html extension.

### DIFF
--- a/src/erlydtl_compiler.erl
+++ b/src/erlydtl_compiler.erl
@@ -117,7 +117,9 @@ compile_dir(Dir, Module) ->
 
 compile_dir(Dir, Module, Options) ->
     Context = init_dtl_context_dir(Dir, Module, Options),
-    Files = filelib:fold_files(Dir, ".+\.html", true, fun(F1,Acc1) -> [F1 | Acc1] end, []),
+    %% Find all files in Dir (recursively), matching the regex (no
+    %% files ending in "~").
+    Files = filelib:fold_files(Dir, ".+[^~]$", true, fun(F1,Acc1) -> [F1 | Acc1] end, []),
     {ParserResults, ParserErrors} = lists:foldl(fun
             (File, {ResultAcc, ErrorAcc}) ->
                 case filename:basename(File) of


### PR DESCRIPTION
Fixes the issue at https://github.com/evanmiller/ChicagoBoss/issues/140 , wrongly attributed to Chicago Boss.
