### PR TITLE
Have truncatewords/2 ignore tuples (e.g. timestamp) and truncatewords/3 ...

### DIFF
--- a/src/erlydtl_filters.erl
+++ b/src/erlydtl_filters.erl
@@ -808,9 +808,6 @@ truncatechars(Input, Max) ->
     truncatechars(Input, Max, []).
 
 %% @doc Truncates a string after a certain number of words.
-%% Do not truncate tuples, e.g. a timestamp ({{Y,M,D},{H,Mm,S}}). 
-truncatewords(Input, _) when is_tuple(Input) ->
-    Input;
 truncatewords(_Input, Max) when Max =< 0 ->
     "";
 truncatewords(Input, Max) when is_binary(Input) ->


### PR DESCRIPTION
...ignore atoms (e.g. null or undefined).
