### PR TITLE
Handle compiler return code, and emit good code for erl_prettypr decompilation.

### DIFF
--- a/src/erlydtl_compiler.erl
+++ b/src/erlydtl_compiler.erl
@@ -86,7 +86,7 @@ compile(Binary, Module, Options) when is_binary(Binary) ->
         {ok, DjangoParseTree} ->
             case compile_to_binary(File, DjangoParseTree, 
                     init_dtl_context(File, Module, Options), CheckSum) of
-                {ok, Module1, _} ->
+                {ok, Module1, _, _} ->
                     {ok, Module1};
                 Err ->
                     Err
@@ -102,8 +102,8 @@ compile(File, Module, Options) ->
             ok;
         {ok, DjangoParseTree, CheckSum} ->
             case compile_to_binary(File, DjangoParseTree, Context, CheckSum) of
-                {ok, Module1, Bin} ->
-                    write_binary(Module1, Bin, Options);
+                {ok, Module1, Bin, Warnings} ->
+                    write_binary(Module1, Bin, Options, Warnings);
                 Err ->
                     Err
             end;
@@ -143,8 +143,8 @@ compile_dir(Dir, Module, Options) ->
     case ParserErrors of
         [] ->
             case compile_multiple_to_binary(Dir, ParserResults, Context) of
-                {ok, Module1, Bin} ->
-                    write_binary(Module1, Bin, Options);
+                {ok, Module1, Bin, Warnings} ->
+                    write_binary(Module1, Bin, Options, Warnings);
                 Err ->
                     Err
             end;
@@ -156,17 +156,32 @@ compile_dir(Dir, Module, Options) ->
 %% Internal functions
 %%====================================================================
 
-write_binary(Module1, Bin, Options) ->
+write_binary(Module1, Bin, Options, Warnings) ->
+    Verbose = proplists:get_value(verbose,
+        proplists:get_value(compiler_options, Options, []), false),
     case proplists:get_value(out_dir, Options) of
         undefined ->
+            Verbose =:= true andalso
+                io:format("Template module: ~w not saved (no out_dir option)\n", [Module1]),
             ok;
         OutDir ->
             BeamFile = filename:join([OutDir, atom_to_list(Module1) ++ ".beam"]),
+
+            Verbose =:= true andalso
+                io:format("Template module: ~w -> ~s~s\n",
+                    [Module1, BeamFile,
+                        case Warnings of
+                        [] -> "";
+                        _  -> io_lib:format("\n  Warnings: ~p", [Warnings])
+                        end]),
+
             case file:write_file(BeamFile, Bin) of
                 ok ->
                     ok;
                 {error, Reason} ->
-                    {error, lists:concat(["beam generation failed (", Reason, "): ", BeamFile])}
+                    {error, lists:flatten(
+                        io_lib:format("Beam generation of '~s' failed: ~p",
+                            [BeamFile, file:format_error(Reason)]))}
             end
     end.
 
@@ -205,17 +220,22 @@ compile_to_binary(File, DjangoParseTree, Context, CheckSum) ->
 compile_forms_and_reload(File, Forms, CompilerOptions) ->
     case compile:forms(Forms, CompilerOptions) of
         {ok, Module1, Bin} -> 
-            code:purge(Module1),
-            case code:load_binary(Module1, atom_to_list(Module1) ++ ".erl", Bin) of
-                {module, _} -> {ok, Module1, Bin};
-                _ -> {error, lists:concat(["code reload failed: ", Module1])}
-            end;
+            load_code(Module1, Bin, []);
+        {ok, Module1, Bin, Warnings} ->
+            load_code(Module1, Bin, Warnings);
         error ->
             {error, lists:concat(["compilation failed: ", File])};
         OtherError ->
             OtherError
     end.
                 
+load_code(Module, Bin, Warnings) ->
+    code:purge(Module),
+    case code:load_binary(Module, atom_to_list(Module) ++ ".erl", Bin) of
+        {module, _} -> {ok, Module, Bin, Warnings};
+        _ -> {error, lists:concat(["code reload failed: ", Module])}
+    end.
+
 init_dtl_context(File, Module, Options) when is_list(Module) ->
     init_dtl_context(File, list_to_atom(Module), Options);
 init_dtl_context(File, Module, Options) ->
@@ -470,6 +490,7 @@ forms(File, Module, {BodyAst, BodyInfo}, {CustomTagsFunctionAst, CustomTagsInfo}
         [erl_syntax:list([erl_syntax:arity_qualifier(erl_syntax:atom(render), erl_syntax:integer(0)),
                     erl_syntax:arity_qualifier(erl_syntax:atom(render), erl_syntax:integer(1)),
                     erl_syntax:arity_qualifier(erl_syntax:atom(render), erl_syntax:integer(2)),
+                    erl_syntax:arity_qualifier(erl_syntax:atom(render_tag), erl_syntax:integer(3)),
                     erl_syntax:arity_qualifier(erl_syntax:atom(source), erl_syntax:integer(0)),
                     erl_syntax:arity_qualifier(erl_syntax:atom(dependencies), erl_syntax:integer(0)),
                     erl_syntax:arity_qualifier(erl_syntax:atom(translatable_strings), erl_syntax:integer(0)),
@@ -1209,17 +1230,22 @@ full_path(File, DocRoot) ->
 %% Custom tags
 %%-------------------------------------------------------------------
 
+key_to_string(Key) when is_atom(Key) ->
+    key_to_string(atom_to_list(Key));
+key_to_string(Key) when is_list(Key) ->
+    erl_syntax:string(Key).
+
 tag_ast(Name, Args, Context, TreeWalker) ->
     {InterpretedArgs, AstInfo} = lists:mapfoldl(fun
             ({{identifier, _, Key}, {string_literal, _, Value}}, AstInfoAcc) ->
                 {{StringAst, StringAstInfo}, _} = string_ast(unescape_string_literal(Value), Context, TreeWalker),
-                {erl_syntax:tuple([erl_syntax:string(Key), StringAst]), merge_info(StringAstInfo, AstInfoAcc)};
+                {erl_syntax:tuple([key_to_string(Key), StringAst]), merge_info(StringAstInfo, AstInfoAcc)};
             ({{identifier, _, Key}, {trans, StringLiteral}}, AstInfoAcc) ->
                 {{TransAst, TransAstInfo}, _} = translated_ast(StringLiteral, Context, TreeWalker),
-                {erl_syntax:tuple([erl_syntax:string(Key), TransAst]), merge_info(TransAstInfo, AstInfoAcc)};
+                {erl_syntax:tuple([key_to_string(Key), TransAst]), merge_info(TransAstInfo, AstInfoAcc)};
             ({{identifier, _, Key}, Value}, AstInfoAcc) ->
                 {AST, VarName} = resolve_variable_ast(Value, Context),
-                {erl_syntax:tuple([erl_syntax:string(Key), format(AST,Context, TreeWalker)]), merge_info(#ast_info{var_names=[VarName]}, AstInfoAcc)}
+                {erl_syntax:tuple([key_to_string(Key), format(AST,Context, TreeWalker)]), merge_info(#ast_info{var_names=[VarName]}, AstInfoAcc)}
         end, #ast_info{}, Args),
 
     {RenderAst, RenderInfo} = custom_tags_modules_ast(Name, InterpretedArgs, Context),


### PR DESCRIPTION
Bug fixes:
1. When compiler_option includes 'return', properly handle Error and Warnings
   returned by the compiler, so that the user still gets 'ok' instead of
   {ok, Module, Bin, {Errors, Warnings}}, which rebar doesn't property handle.
1. When compiling templates with custom tags with a given custom_tags_modules
   option, the arguments were saved as atoms in the AST as opposed to strings.
   This caused a failure when decompiling the beam and printing its source
   by erl_prettypr.
2. Local unused function render_tags/3 emitted in templates was compiling with
   a warning.  Made it exported to suppress the warnings.

In order to illustrate the issue compile the template test.dtl containing:

```
{% tr xxx="ABC" %}
```

with options:

```
[
    , {doc_root, "src"}
    , {out_dir,   "ebin"}
    , {compiler_options, [verbose, debug_info, report, return]}
    , {custom_tags_modules, [custom_tags]}
    , {force_recompile, true}
].
```

where custom_tags module is:

```
-module(custom_tags).

-export([tr/2]).

tr(Vars, Context) ->
    io:format("Vars: ~p\n  Context: ~p\n", [Vars, Context]),
    [].
```

Observe the return code of erlydtl_compiler:compile/3, and also try to
decompile the emitted beam with:
[http://erlang.org/pipermail/erlang-questions/2006-January/018813.html]
