### PR TITLE
Added variables/0 exported function to compiled templates

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -169,6 +169,11 @@ List of names/checksums of templates included by the original template
 file. Useful for frameworks that recompile a template only when the
 template's dependencies change.
 
+    my_compiled_template:variables() -> [Variable::atom()]
+
+Sorted list of unique variables used in the template's body. The list can
+be used for determining which variable bindings need to be passed to the
+render/3 function.
 
 Differences from standard Django Template Language
 --------------------------------------------------

--- a/src/erlydtl_compiler.erl
+++ b/src/erlydtl_compiler.erl
@@ -385,6 +385,11 @@ translated_blocks_function(TranslatedBlocks) ->
                             end,
                             TranslatedBlocks))])]).
 
+variables_function(Variables) ->
+        erl_syntax:function(
+        erl_syntax:atom(variables), [erl_syntax:clause([], none,
+                [erl_syntax:list([erl_syntax:atom(S) || S <- lists:usort(Variables)])])]). 
+
 custom_forms(Dir, Module, Functions, AstInfo) ->
     ModuleAst = erl_syntax:attribute(erl_syntax:atom(module), [erl_syntax:atom(Module)]),
     ExportAst = erl_syntax:attribute(erl_syntax:atom(export),
@@ -453,6 +458,8 @@ forms(File, Module, {BodyAst, BodyInfo}, {CustomTagsFunctionAst, CustomTagsInfo}
 
     TranslatedBlocksAst = translated_blocks_function(MergedInfo#ast_info.translated_blocks),
 
+    VariablesAst = variables_function(MergedInfo#ast_info.var_names),
+
     BodyAstTmp = erl_syntax:application(
                     erl_syntax:atom(erlydtl_runtime),
                     erl_syntax:atom(stringify_final),
@@ -473,11 +480,13 @@ forms(File, Module, {BodyAst, BodyInfo}, {CustomTagsFunctionAst, CustomTagsInfo}
                     erl_syntax:arity_qualifier(erl_syntax:atom(source), erl_syntax:integer(0)),
                     erl_syntax:arity_qualifier(erl_syntax:atom(dependencies), erl_syntax:integer(0)),
                     erl_syntax:arity_qualifier(erl_syntax:atom(translatable_strings), erl_syntax:integer(0)),
-                    erl_syntax:arity_qualifier(erl_syntax:atom(translated_blocks), erl_syntax:integer(0))
+                    erl_syntax:arity_qualifier(erl_syntax:atom(translated_blocks), erl_syntax:integer(0)),
+                    erl_syntax:arity_qualifier(erl_syntax:atom(variables), erl_syntax:integer(0))
                 ])]),
     
     [erl_syntax:revert(X) || X <- [ModuleAst, ExportAst, Render0FunctionAst, Render1FunctionAst, Render2FunctionAst,
-            SourceFunctionAst, DependenciesFunctionAst, TranslatableStringsAst, TranslatedBlocksAst, RenderInternalFunctionAst, 
+            SourceFunctionAst, DependenciesFunctionAst, TranslatableStringsAst,
+            TranslatedBlocksAst, VariablesAst, RenderInternalFunctionAst, 
             CustomTagsFunctionAst | BodyInfo#ast_info.pre_render_asts]].    
 
         


### PR DESCRIPTION
This function eases debugging of template rendering issues by providing
run-time information about what variables are expected by the template.
