### PR TITLE
Add support for variables (and expressions) in include and ssi tags

### DIFF
--- a/src/erlydtl_parser.yrl
+++ b/src/erlydtl_parser.yrl
@@ -260,10 +260,10 @@ EndBlockBraced -> open_tag endblock_keyword close_tag.
 
 ExtendsTag -> open_tag extends_keyword string_literal close_tag : {extends, '$3'}.
 
-IncludeTag -> open_tag include_keyword string_literal close_tag : {include, '$3', []}.
-IncludeTag -> open_tag include_keyword string_literal with_keyword Args close_tag : {include, '$3', '$5'}.
-IncludeTag -> open_tag include_keyword string_literal only_keyword close_tag : {include_only, '$3', []}.
-IncludeTag -> open_tag include_keyword string_literal with_keyword Args only_keyword close_tag : {include_only, '$3', '$5'}.
+IncludeTag -> open_tag include_keyword Value close_tag : {include, '$3', []}.
+IncludeTag -> open_tag include_keyword Value with_keyword Args close_tag : {include, '$3', '$5'}.
+IncludeTag -> open_tag include_keyword Value only_keyword close_tag : {include_only, '$3', []}.
+IncludeTag -> open_tag include_keyword Value with_keyword Args only_keyword close_tag : {include_only, '$3', '$5'}.
 
 NowTag -> open_tag now_keyword string_literal close_tag : {date, now, '$3'}.
 
@@ -351,7 +351,7 @@ EndRegroupBraced -> open_tag endregroup_keyword close_tag.
 SpacelessBlock -> open_tag spaceless_keyword close_tag Elements open_tag endspaceless_keyword close_tag : {spaceless, '$4'}.
 
 SSITag -> open_tag ssi_keyword Value close_tag : {ssi, '$3'}.
-SSITag -> open_tag ssi_keyword string_literal parsed_keyword close_tag : {ssi_parsed, '$3'}.
+SSITag -> open_tag ssi_keyword Value parsed_keyword close_tag : {ssi_parsed, '$3'}.
 
 BlockTransBlock -> open_tag blocktrans_keyword close_tag Elements open_tag endblocktrans_keyword close_tag : {blocktrans, [], '$4'}.
 BlockTransBlock -> open_tag blocktrans_keyword with_keyword Args close_tag Elements open_tag endblocktrans_keyword close_tag : {blocktrans, '$4', '$6'}.

--- a/src/erlydtl_runtime.erl
+++ b/src/erlydtl_runtime.erl
@@ -275,9 +275,42 @@ spaceless(Contents) ->
     Contents4.
 
 read_file(Module, Function, DocRoot, FileName) ->
-    AbsName = case filename:absname(FileName) of
-        FileName -> FileName;
-        _ -> filename:join([DocRoot, FileName])
-    end,
+    AbsName = erlydtl_compiler:full_path(FileName, DocRoot),
     {ok, Binary} = Module:Function(AbsName),
     binary_to_list(Binary).
+
+include_file(DocRoot, FileName, ParentModule, Options, Variables, RenderOptions) when is_binary(FileName) ->
+    include_file(DocRoot, unicode:characters_to_list(FileName), ParentModule, Options, Variables, RenderOptions);
+include_file(DocRoot, FileName, ParentModule, Options, Variables, RenderOptions) when is_list(FileName) ->
+    Module = partial_module(ParentModule, FileName),
+    % We do not recompile if the module exists, even if force_recompile is true.
+    % Indeed, we cannot be sure that, at runtime, user wants the template to
+    % be re-compiled, or that the source code can actually be found.
+    case code:ensure_loaded(Module) of
+        {module, Module} -> ok;
+        {error, _} ->
+            AbsName = erlydtl_compiler:full_path(FileName, DocRoot),
+            case erlydtl_compiler:compile(AbsName, Module, Options) of
+                ok -> ok;
+                Err ->
+                    throw(Err)
+            end
+    end,
+    {ok, Rendered} = Module:render(Variables, RenderOptions),
+    Rendered.
+
+% Compute the boss_load:view_module/2 module for a-runtime included partial.
+% However, we do not know the application. We'll try to guess it from the
+% first occurrence of "_view_" in the parent module. If it fails, we're not
+% in a boss application and we'll use parent module as the prefix.
+partial_module(ParentModule, FileName) ->
+    ParentModuleList = atom_to_list(ParentModule),
+    Prefix = case string:str(ParentModuleList, "_view_") of
+        0 -> ParentModuleList;
+        Index -> lists:sublist(ParentModuleList, Index + 4)
+    end,
+    Components = filename:split(FileName),
+    Lc = string:to_lower(lists:concat([Prefix, "_", string:join(Components, "_")])),
+    LcBin = unicode:characters_to_binary(Lc),
+    ModuleBin = binary:replace(LcBin, <<".">>, <<"_">>, [global]),
+    binary_to_atom(ModuleBin, utf8).

--- a/tests/input/include_expr
+++ b/tests/input/include_expr
@@ -1,0 +1,1 @@
+Including another file: {% include "inc"|add:"lude.html" with var1=var1 only %}

--- a/tests/input/include_path_expr
+++ b/tests/input/include_path_expr
@@ -1,0 +1,5 @@
+main file
+
+{% ssi "path1/"|add:"template1" parsed %}
+
+{{ base_var }}

--- a/tests/input/include_template_expr
+++ b/tests/input/include_template_expr
@@ -1,0 +1,3 @@
+Including another template: {% include "ba"|add:"se" %}
+
+test variable: {{ test_var }}

--- a/tests/src/erlydtl_functional_tests.erl
+++ b/tests/src/erlydtl_functional_tests.erl
@@ -42,12 +42,12 @@ test_list() ->
 % order is important.
     ["autoescape", "comment", "extends", "filters", "for", "for_list",
         "for_tuple", "for_list_preset", "for_preset", "for_records",
-        "for_records_preset", "include", "if", "if_preset", "ifequal",
+        "for_records_preset", "include", "include_expr", "if", "if_preset", "ifequal",
         "ifequal_preset", "ifnotequal", "ifnotequal_preset", "now",
         "var", "var_preset", "cycle",
         "custom_tag", "custom_tag1", "custom_tag2", "custom_tag3",
         "custom_call", 
-        "include_template", "include_path", "ssi",
+        "include_template", "include_template_expr", "include_path", "include_path_expr", "ssi",
         "extends_path", "extends_path2", "trans" ].
 
 setup_compile("for_list_preset") ->
@@ -119,6 +119,9 @@ setup("for_records_preset") ->
 setup("include") ->
     RenderVars = [{var1, "foostring1"}, {var2, "foostring2"}],
     {ok, RenderVars};
+setup("include_expr") ->
+    RenderVars = [{var1, "foostring1"}, {var2, "foostring2"}],
+    {ok, RenderVars};
 setup("if") ->
     RenderVars = [{var1, "something"}],
     {ok, RenderVars}; 
@@ -144,7 +147,13 @@ setup("cycle") ->
 setup("include_template") ->
     RenderVars = [{base_var, "base-barstring"}, {test_var, "test-barstring"}],
     {ok, RenderVars};
+setup("include_template_expr") ->
+    RenderVars = [{base_var, "base-barstring"}, {test_var, "test-barstring"}],
+    {ok, RenderVars};
 setup("include_path") ->
+    RenderVars = [{base_var, "base-barstring"}, {test_var, "test-barstring"}],
+    {ok, RenderVars};
+setup("include_path_expr") ->
     RenderVars = [{base_var, "base-barstring"}, {test_var, "test-barstring"}],
     {ok, RenderVars};
 setup("extends_path") ->


### PR DESCRIPTION
Django documentation mentions that first argument of include and ssi tags (the template name/path of included file) can be a literal or a context variable. In fact, an expression with filters seem to also work. Make it likewise in erlydtl.

The implementation is a compromise based on possible differences between runtime and compile time. Previous behavior is maintained identically. Yet, there are subtle differences between a partial template included from an expression (searched at runtime) and a partial template included from a literal (searched at compile time):
- if compile time variables contain structures that cannot be abstracted or that would not work at runtime, then compilation or rendering will fail. Typically, functions cannot be abstracted (a workaround would be to serialize them to binary, but they still might fail at runtime);
- to avoid failure with `blocktrans_fun`, this option is simply removed and not passed from compile time to runtime. As a consequence, partials included at runtime cannot contain translated blocks;
- the name of the module is guessed based on a heuristic that works with [ChicagoBoss](https://github.com/evanmiller/ChicagoBoss) but might fail with other applications using erlydtl. Indeed there is no way to guess what a production environment wants to compile a template to. As a result, partials included at runtime might require to be compiled at runtime a second time (under a different module name). This recompilation might fail as the environment might differ;
- no effort is made to recompile the included template if it is already available. This is a serious drawback for development but is required as there is no way to make sure user wants the template to be recompiled at runtime based on information available at compile_time. Looking for the source of the template might fail in some deployments and can be judged expensive anyway.

Some of these drawbacks could be alleviated by changing a little bit the coupling between erlydtl and the frameworks. For example, if `blocktrans_fun` was replaced by a `{M, F}` pair, it could be abstracted. Likewise, instead of passing the module name, the client could provide a `{M, F}` reference to a function that transforms a filename into a module, and this function could be called at runtime from `erlydtl_runtime:include_file/6`.
