### PR TITLE
Don't crash when a loop variable isn't defined

### DIFF
--- a/src/erlydtl_runtime.erl
+++ b/src/erlydtl_runtime.erl
@@ -206,6 +206,9 @@ stringify_final([El | Rest], Out, BinaryStrings) ->
 init_counter_stats(List) ->
     init_counter_stats(List, undefined).
 
+init_counter_stats(undefined, Parent) ->
+  init_counter_stats([], Parent);
+
 init_counter_stats(List, Parent) when is_list(List) ->
     [{counter, 1}, 
         {counter0, 0}, 


### PR DESCRIPTION
If a loop variable isn't defined, we treat it like it is an empty list.
This brings the behavior in line with the python DTL implementation.
## 

I would like to review this
