### PR TITLE
Make escapejs work with 'line separator' 8232 and 'paragraph separator' ...

### DIFF
--- a/src/erlydtl_filters.erl
+++ b/src/erlydtl_filters.erl
@@ -296,7 +296,7 @@ divisibleby(Input, Divisor) when is_integer(Input), is_integer(Divisor) ->
 
 %% @doc Escapes characters for use in JavaScript strings.
 escapejs(Input) when is_binary(Input) ->
-    escapejs(binary_to_list(Input));
+    escapejs(unicode:characters_to_list(Input));
 escapejs(Input) when is_list(Input) ->
     escapejs(Input, []).
 


### PR DESCRIPTION
Line separator character is represented as a binary in following way:

``` erlang
<<226,128,168>>
binary_to_list(<<226,128,168>>) = [226,128,168],
```

To properly handle line separator and paragraph separator,
escapejs requires list of characters, which contains integer 8232.

``` erlang
unicode:characters_to_list(<<226,128,168>>) = [8232].
```

This patch uses `unicode:character_to_list/1` to make line separator one character.

Another way to fix problem with line separator is
adding another two clauses to `escapejs/2`

``` erlang
escapejs([226, 128, 168 | Rest], Acc) -> ...
escapejs([226, 128, 169 | Rest], Acc) -> ...
```

but using `unicode:characters_to_list/1` is simpler and does the job.
