### PR TITLE
Fix escapejs return type

### DIFF
--- a/src/erlydtl_filters.erl
+++ b/src/erlydtl_filters.erl
@@ -296,7 +296,7 @@ divisibleby(Input, Divisor) when is_integer(Input), is_integer(Divisor) ->
 
 %% @doc Escapes characters for use in JavaScript strings.
 escapejs(Input) when is_binary(Input) ->
-    escapejs(unicode:characters_to_list(Input));
+    unicode:characters_to_binary(escapejs(unicode:characters_to_list(Input)));
 escapejs(Input) when is_list(Input) ->
     escapejs(Input, []).
 


### PR DESCRIPTION
This commit changes `escapejs` filter to return binary, when it received binary as input.

Couple of weeks ago I proposed to use `unicode:characters_to_list` in `escapejs` to fix a bug
with handling 'line separator' and 'paragraph separator'.

Even, when it got binary as input, `escapejs` returned list as output,
so I left it that way, but I believe, it should return binary, when it receives binary.
For example `first` filter works this way.
