### PR TITLE
When compiling on FreeBSD, use gmake instead of make.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,6 +11,7 @@
 
 {pre_hooks,
  [{compile, "make -C $REBAR_DEPS_DIR/merl all"},
+  {"freebsd", compile, "gmake -C $REBAR_DEPS_DIR/merl all"},
   {eunit,
    "erlc -I include/erlydtl_preparser.hrl -o test"
    " test/erlydtl_extension_testparser.yrl"}


### PR DESCRIPTION
Without this patch, erlydtl compilation on FreeBSD fails with the following:

snar@mars:~/compile/tmp/erlydtl>./rebar compile
==> erlydtl (compile)
erl -noshell -pa ebin  -eval 'eunit:test("ebin",[])'  -s init stop
  There were no tests to run.
Compiled src/erlydtl_parser.yrl
Compiled src/erlydtl_library.erl
[....]
Compiled src/erlydtl_contrib_humanize.erl
src/erlydtl_beam_compiler.erl:none: undefined parse transform 'merl_transform'
ERROR: compile failed while processing /usr/home/snar/compile/tmp/erlydtl: rebar_abort
