### PR TITLE
Fix ensure_dir when debug_root is specified

### DIFF
--- a/src/erlydtl_beam_compiler.erl
+++ b/src/erlydtl_beam_compiler.erl
@@ -289,17 +289,13 @@ maybe_debug_template(Forms, Context) ->
                                    SourceFile,
                                    Context#dtl_context.doc_root),
                                        Dir),
-                               case filelib:is_dir(Dir) of
-                                   true -> Abs;
-                                   false ->
-                                       case filelib:ensure_dir(Abs) of
-                                           ok -> Abs;
-                                           {error, Reason} ->
-                                               io:format(
-                                                 "Failed to ensure directories for file '~s': ~p~n",
-                                                 [Abs, Reason]),
-                                               undefined
-                                       end
+                               case filelib:ensure_dir(Abs) of
+                                   ok -> Abs;
+                                   {error, Reason} ->
+                                       io:format(
+                                         "Failed to ensure directories for file '~s': ~p~n",
+                                         [Abs, Reason]),
+                                       undefined
                                end
                        end,
                 if File =/= undefined ->


### PR DESCRIPTION
From commit's extended message:

Previously, we were checking if the directory exists, but not checking
it with respect to the doc_root exists.  Instead, we were ensuring the
directory with respect only to the originally provided "debug_root".

This patch ensures (har har) that when we are ensuring the directory for
debug purposes, that it includes the full path to the file.

_Additionally_ calling filelib:ensure_dir(Dir) will only ensure the
directories up to the _parent_ of Dir.  It's a little bit wonky, so
typically one would append a "dummy" file to a Dir path.  But we don't
need to do this since Abs is itself a file, so we ensure_dir(Abs), and
it'll ensure all the directories correctly.

Example: filelib:ensure_dir("/foo/bar/whatever/something"), will only
ensure that the directories "/foo/bar/whatever" exist and will create
them if necessary. "something" is not actually used.

The short of it is that this will fix debug_root if a doc_root is
specified, and the File to be compiled is specified with directories as
well, such as "src/view/whatever.html". Further, it shortens the code
up a bit, removing the unnecessary is_dir call.
