### PR TITLE
Merl is an application dependency

### DIFF
--- a/src/erlydtl.app.src
+++ b/src/erlydtl.app.src
@@ -3,6 +3,6 @@
  [{description, "Django Template Language for Erlang"},
   {vsn, git},
   {modules, []},
-  {applications, [kernel, stdlib, compiler, syntax_tools]},
+  {applications, [kernel, stdlib, compiler, syntax_tools, merl]},
   {registered, []}
  ]}.


### PR DESCRIPTION
I might be missing something here - but if I do a release with relx, merl doesn't come through and therefore erlydtl doesn't work.
