### PR TITLE
Fix quoting in pre_hooks to get it compiling when folder name has spaces...

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,11 +26,11 @@
  ]}.
 
 {pre_hooks,
- [{compile, "make -C $REBAR_DEPS_DIR/merl all -W test"},
-  {"freebsd", compile, "gmake -C $REBAR_DEPS_DIR/merl all"},
+ [{compile, "make -C \"$REBAR_DEPS_DIR/merl\" all -W test"},
+  {"freebsd", compile, "gmake -C \"$REBAR_DEPS_DIR/merl\" all"},
   {eunit,
    "erlc -I include/erlydtl_preparser.hrl -o test"
    " test/erlydtl_extension_testparser.yrl"},
-  {eunit, "make -C $REBAR_DEPS_DIR/merl test"},
-  {"freebsd", eunit, "gmake -C $REBAR_DEPS_DIR/merl test"}
+  {eunit, "make -C \"$REBAR_DEPS_DIR/merl\" test"},
+  {"freebsd", eunit, "gmake -C \"$REBAR_DEPS_DIR/merl\" test"}
  ]}.


### PR DESCRIPTION
In rebar.config the pre_hooks make command has unquoted path references, so when built from a folder that has spaces in the name it will fail to find correct folder.

Just quoted the path to get it working.

The fix is more relevant when using erlydtl as dependency in rebar project, which happens to be placed on a path with spaces.

Thanks.
