### PR TITLE
change $REBAR_DEPS_DIR to %REBAR_DEPS_DIR% for windows compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,11 +26,13 @@
  ]}.
 
 {pre_hooks,
- [{compile, "make -C \"$REBAR_DEPS_DIR/merl\" all -W test"},
-  {"freebsd", compile, "gmake -C \"$REBAR_DEPS_DIR/merl\" all"},
+ [{"(linux|darwin|solaris)", compile, "make -C \"$REBAR_DEPS_DIR/merl\" all -W test"},
+  {"(freebsd|netbsd|openbsd)", compile, "gmake -C \"$REBAR_DEPS_DIR/merl\" all"},
+  {"win32", compile, "make -C \"%REBAR_DEPS_DIR%/merl\" all -W test"},
   {eunit,
    "erlc -I include/erlydtl_preparser.hrl -o test"
    " test/erlydtl_extension_testparser.yrl"},
-  {eunit, "make -C \"$REBAR_DEPS_DIR/merl\" test"},
-  {"freebsd", eunit, "gmake -C \"$REBAR_DEPS_DIR/merl\" test"}
+  {"(linux|darwin|solaris)", eunit, "make -C \"$REBAR_DEPS_DIR/merl\" test"},
+  {"(freebsd|netbsd|openbsd)", eunit, "gmake -C \"$REBAR_DEPS_DIR/merl\" test"},
+  {"win32", eunit, "make -C \"%REBAR_DEPS_DIR%/merl\" test"}
  ]}.


### PR DESCRIPTION
if there is a make.exe in the %PATH% (e.g. from the UnxUtils http://unxutils.sourceforge.net/), erlydtl works now on windows
