### PR TITLE
Fix bug when library module implements several behaviours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ tests/output
 deps
 .emacs*
 .eunit
+/.edts
+/.rebar/
+/*.beam

--- a/src/erlydtl_compiler_utils.erl
+++ b/src/erlydtl_compiler_utils.erl
@@ -483,21 +483,26 @@ lib_module(Name, #dtl_context{ libraries=Libs }) ->
     Mod = proplists:get_value(Name, Libs, Name),
     case code:ensure_loaded(Mod) of
         {module, Mod} ->
-            IsLib = case proplists:get_value(behaviour, Mod:module_info(attributes)) of
-                        Behaviours when is_list(Behaviours) ->
-                            lists:member(erlydtl_library, Behaviours);
-                        _ -> false
-                    end,
-            if IsLib ->
+            case is_library_behaviour_implemented(Mod) of
+                true ->
                     case Mod:version() of
                         ?LIB_VERSION -> {ok, Mod};
                         V -> {load_library, Name, Mod, {version, V}}
                     end;
-               true -> {load_library, Name, Mod, behaviour}
+               false -> {load_library, Name, Mod, behaviour}
             end;
         {error, Reason} ->
             {load_library, Name, Mod, Reason}
     end.
+
+is_library_behaviour_implemented(Mod) ->
+    lists:any(
+      fun({behaviour, BehavioursList}) ->
+              lists:member(erlydtl_library, BehavioursList);
+         (_) ->
+              false
+      end,
+      Mod:module_info(attributes)).
 
 read_library(Mod, Section, Which) ->
     [{Name, lib_function(Mod, Fun)}
@@ -530,4 +535,3 @@ remove_first_quote(String) ->
 
 remove_last_quote(String) ->
     lists:reverse(remove_first_quote(lists:reverse(String))).
-  

--- a/test/erlydtl_lib_test1.erl
+++ b/test/erlydtl_lib_test1.erl
@@ -1,7 +1,14 @@
 -module(erlydtl_lib_test1).
+-behaviour(erlydtl_lib_test1). %% for test multiple behaviours
 -behaviour(erlydtl_library).
 
 -export([version/0, inventory/1, reverse/1]).
+
+-export([behaviour_info/1]).
+
+behaviour_info(callbacks) ->
+    [
+    ].
 
 version() -> 1.
 


### PR DESCRIPTION
Library module should be able to implement several behaviours, e.g. gen_server, erlydtl_library or something else. In this case ```
Mod:module_info(attributes)``` can return list with multiple ```{behaviour, BehavioursList}``` tuples, ```proplists:get_value(behaviour, Attrs)``` check only first item.