### PR TITLE
mostly travis-ci stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ deps
 /.edts
 /.rebar/
 /*.beam
+/.settings/
+/.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ otp_release:
    - R16B02
    - R16B01
    - R16B
-#  - R15B03-1 not available on travis
-   - R15B03
-   - R15B02
-   - R15B01
-   - R15B
+
 
 # since Travis is naughty and calls rebar get-deps behind our backs,
 # we'll have to clean it up and build merl our selves..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 language: erlang
 otp_release:
 # Test on all supported releases accepted by the `require_otp_vsn` in rebar.config
-#  - 17.0 not yet available on travis!
-  - 17.3
-  - R16B03-1
-#  - R16B03 this version is broken!
-  - R16B02
-  - R16B01
-  - R16B
+   - 17.4
+   - 17.3
+   - 17.1
+   - 17.0
+   - R16B03-1
+#   - R16B03 this version is broken!
+   - R16B02
+   - R16B01
+   - R16B
 #  - R15B03-1 not available on travis
-  - R15B03
-  - R15B02
+   - R15B03
+   - R15B02
+   - R15B01
+   - R15B
 
 # since Travis is naughty and calls rebar get-deps behind our backs,
 # we'll have to clean it up and build merl our selves..
 script: "make -C deps/merl && make tests"
-
+  - mkdir plt
+  - ./travis-dialyzer.sh
 notifications:
   irc: "chat.freenode.net#erlydtl"
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ otp_release:
 
 # since Travis is naughty and calls rebar get-deps behind our backs,
 # we'll have to clean it up and build merl our selves..
-script: "make -C deps/merl && make tests"
+script: 
+  - "make -C deps/merl && make tests"
   - mkdir plt
   - ./travis-dialyzer.sh
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ dialyze:
 PLT_APPS ?=
 plt:
 	@dialyzer -n -nn --build_plt --apps \
-		compiler erts eunit syntax_tools
+		kernel stdlib compiler erts eunit syntax_tools
 
 clean:
 	@echo "Clean merl..." ; $(MAKE) -C deps/merl clean

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,7 @@ dialyze:
 PLT_APPS ?=
 plt:
 	@dialyzer -n -nn --build_plt --apps \
-		erts kernel stdlib sasl compiler \
-		crypto syntax_tools runtime_tools \
-		tools webtool hipe inets eunit
+		compiler erts eunit syntax_tools
 
 clean:
 	@echo "Clean merl..." ; $(MAKE) -C deps/merl clean

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 %% -*- mode: erlang -*-
 
-%% accept R15B02.., any R16B except R16B03
+%% accept any R16B except R16B03
 %% also accept OTP v17, altough it may not work properly on that release yet..
-{require_otp_vsn, "R15B0[^1]|R16B$|R16B[^0]|R16B0[^3]|R16B03-1|17"}.
+{require_otp_vsn, "R16B$|R16B[^0]|R16B0[^3]|R16B03-1|17"}.
 
 {erl_opts, [debug_info]}.
 {yrl_opts, [{includefile, "include/erlydtl_preparser.hrl"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,9 @@
    {git, "git://github.com/erlydtl/merl.git", {branch, "erlydtl"}},
    [raw]},
   {eunit_formatters, ".*",
-   {git, "git://github.com/seancribbs/eunit_formatters", {branch, "master"}}}
+   {git, "git://github.com/seancribbs/eunit_formatters.git", {branch, "master"}}},
+ {gettext, ".*",
+   {git, "git://github.com/etnt/gettext.git", {branch, "master"}}}
  ]}.
 
 {pre_hooks,

--- a/travis-dialyzer.sh
+++ b/travis-dialyzer.sh
@@ -8,7 +8,7 @@ dialyzer  --build_plt --apps kernel stdlib\
        --output_plt $PLT > /dev/null
 
 echo "********************************************************************************"
-for app in  erts 
+for app in  erts eunit gettext syntax_tools
 do 
     echo $"Adding $app"
     dialyzer --add_to_plt --apps $app\

--- a/travis-dialyzer.sh
+++ b/travis-dialyzer.sh
@@ -32,6 +32,6 @@ dialyzer	ebin/			\
     -Wunmatched_returns	\
     --verbose				\
     --fullpath				\
-    -n						\
+    --statistics			\
     --plt $PLT
 #

--- a/travis-dialyzer.sh
+++ b/travis-dialyzer.sh
@@ -8,7 +8,7 @@ dialyzer  --build_plt --apps kernel stdlib\
        --output_plt $PLT > /dev/null
 
 echo "********************************************************************************"
-for app in  erts eunit gettext syntax_tools
+for app in  compiler erts eunit gettext syntax_tools
 do 
     echo $"Adding $app"
     dialyzer --add_to_plt --apps $app\

--- a/travis-dialyzer.sh
+++ b/travis-dialyzer.sh
@@ -16,6 +16,7 @@ do
 done
 
 echo "********************************************************************************"
+rm -f deps/merl/priv/merl_transform.beam
 for app in $(ls deps/)
 do
    echo "Adding $app"

--- a/travis-dialyzer.sh
+++ b/travis-dialyzer.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+PLT=plt/erlydtl-$RANDOM.plt
+echo "PLT File $PLT"
+export PATH=$PATH:/usr/local/bin:/usr/bin
+echo "Building PLT, may take a few minutes"
+dialyzer  --build_plt --apps kernel stdlib\
+       --output_plt $PLT > /dev/null
+
+echo "********************************************************************************"
+for app in  erts 
+do 
+    echo $"Adding $app"
+    dialyzer --add_to_plt --apps $app\
+       --plt $PLT > /dev/null
+done
+
+echo "********************************************************************************"
+for app in $(ls deps/)
+do
+   echo "Adding $app"
+   dialyzer --add_to_plt --apps deps/$app \
+       --plt $PLT > /dev/null
+done
+echo "********************************************************************************"
+echo ""
+
+dialyzer	ebin/			\
+    -Werror_handling		\
+    -Wrace_conditions		\
+    -Wunderspecs			\
+    -Wunmatched_returns	\
+    --verbose				\
+    --fullpath				\
+    -n						\
+    --plt $PLT
+#

--- a/travis-dialyzer.sh
+++ b/travis-dialyzer.sh
@@ -8,7 +8,7 @@ dialyzer  --build_plt --apps kernel stdlib\
        --output_plt $PLT > /dev/null
 
 echo "********************************************************************************"
-for app in  compiler erts eunit gettext syntax_tools
+for app in  compiler erts eunit syntax_tools
 do 
     echo $"Adding $app"
     dialyzer --add_to_plt --apps $app\


### PR DESCRIPTION
* create plt with minimal number of apps required
* add script to build PLT and analyze it
* add missing gettext dependency
* **make R16B minimal version**

travis-ci tests are more verbose now and failing on dialyzer. 

requires erlydtl/merl#3 to work properly