### PR TITLE
Adding  support for "Assignment tags"

### DIFF
--- a/src/erlydtl_parser.yrl
+++ b/src/erlydtl_parser.yrl
@@ -447,6 +447,7 @@ WithBraced -> open_tag with_keyword Args close_tag : '$3'.
 EndWithBraced -> open_tag endwith_keyword close_tag.
 
 CustomTag -> open_tag identifier CustomArgs close_tag : {tag, '$2', '$3'}.
+CustomTag -> open_tag identifier CustomArgs as_keyword identifier close_tag : {tag, '$2', '$3', '$5'}.
 
 CustomArgs -> '$empty' : [].
 CustomArgs -> identifier '=' Value CustomArgs : [{'$1', '$3'}|'$4'].

--- a/test/erlydtl_custom_tags.erl
+++ b/test/erlydtl_custom_tags.erl
@@ -1,6 +1,6 @@
 -module(erlydtl_custom_tags).
 
--export([custom1/1, custom2/2, custom3/2, custom4/1]).
+-export([custom1/1, custom2/2, custom3/2, custom4/1, custom1_var/2]).
 
 custom1(_TagVars = []) ->
     <<"b1">>.
@@ -13,3 +13,6 @@ custom3([], _RenderOptions = [{locale, ru}]) ->
 
 custom4(_TagVars = [<<"a">>]) ->
     <<"a">>.
+
+custom1_var(_TagVars = [], _O) ->
+[{name, <<"b1">>}, {count, 11}].

--- a/test/erlydtl_custom_tags_lib.erl
+++ b/test/erlydtl_custom_tags_lib.erl
@@ -1,0 +1,11 @@
+-module(erlydtl_custom_tags_lib).
+-behaviour(erlydtl_library).
+
+-export([version/0, inventory/1, customtag2_var/2]).
+
+version() -> 1.
+
+inventory(filters) -> [];
+inventory(tags) -> [customtag2_var].
+
+customtag2_var(_V,_R) -> [{name, <<"b1">>}, {count, 11}].

--- a/test/erlydtl_test_defs.erl
+++ b/test/erlydtl_test_defs.erl
@@ -1737,7 +1737,7 @@ all_test_defs() ->
                 "for_list_preset", "for_preset", "for_records", "for_records_preset", "include",
                 "if", "if_preset", "ifequal", "ifequal_preset", "ifnotequal", "ifnotequal_preset",
                 "now", "var", "var_preset", "cycle", "custom_tag", "custom_tag1", "custom_tag2",
-                "custom_tag3", "custom_tag4", "custom_call", "include_template", "include_path",
+                "custom_tag3", "custom_tag4", "custom_tag_var", "custom_tag_lib_var", "custom_call", "include_template", "include_path",
                 "ssi", "extends_path", "extends_path2", "trans", "extends_for", "extends2",
                 "extends3", "recursive_block", "extend_recursive_block", "missing", "block_super",
                 "wrapper", "extends4", "super_escaped", "extends_chain"]
@@ -1913,6 +1913,9 @@ setup_compile("custom_tag1") -> setup_compile("custom_tag");
 setup_compile("custom_tag2") -> setup_compile("custom_tag");
 setup_compile("custom_tag3") -> setup_compile("custom_tag");
 setup_compile("custom_tag4") -> setup_compile("custom_tag");
+setup_compile("custom_tag_var") -> setup_compile("custom_tag");
+setup_compile("custom_tag_lib_var") ->
+ {ok, [[]|[{compile_opts, [{libraries, [{custom_tag_lib,erlydtl_custom_tags_lib}]}, {default_libraries, [custom_tag_lib]}]}]]};
 setup_compile("super_escaped") ->
     {ok, [[]|[{compile_opts, [auto_escape]}]]};
 setup_compile(_) ->
@@ -2028,6 +2031,10 @@ setup("custom_tag3") ->
     {ok, [{a, <<"a1">>}], [{locale, ru}], <<"b3\n">>};
 setup("custom_tag4") ->
     {ok, [], [], <<"a\n">>};
+setup("custom_tag_var") ->
+ {ok, [{a, <<"a1">>}], [{locale, ru}], <<"\nb1\n11\n">>};
+setup("custom_tag_lib_var") ->
+ {ok, [{a, <<"a1">>}], [{locale, ru}], <<"\nb1\n11\n">>};
 setup("ssi") ->
     RenderVars = [{path, "ssi_include.html"}],
     {ok, RenderVars};

--- a/test/files/input/custom_tag_lib_var
+++ b/test/files/input/custom_tag_lib_var
@@ -1,0 +1,3 @@
+{% customtag2_var as tagvar %}
+{{ tagvar.name }}
+{{ tagvar.count }}

--- a/test/files/input/custom_tag_var
+++ b/test/files/input/custom_tag_var
@@ -1,0 +1,3 @@
+{% custom1_var as tagvar %}
+{{ tagvar.name }}
+{{ tagvar.count }}


### PR DESCRIPTION
 (https://docs.djangoproject.com/en/1.6/howto/custom-template-tags/#howto-custom-template-tags-assignment-tags)
example: 
* {% custom_tag as var_tag %}{{ var_tag }} more {{ var_tag }}
* {% custom_tag1 as var_tag1 %}{{ var_tag1.name }} 
more {{ var_tag1.some }}
