### PR TITLE
Allow custom library use either of behaviOUr or behaviOr.

### DIFF
--- a/src/erlydtl_compiler_utils.erl
+++ b/src/erlydtl_compiler_utils.erl
@@ -496,7 +496,11 @@ lib_module(Name, #dtl_context{ libraries=Libs }) ->
     end.
 
 implements_behaviour(Behaviour, Mod) ->
-    [] =:= [Behaviour] -- [B || [B] <- proplists:get_all_values(behaviour, Mod:module_info(attributes))].
+    Attrs = Mod:module_info(attributes),
+    Found =
+        [B || [B] <- proplists:get_all_values(behaviour, Attrs)] ++
+        [B || [B] <- proplists:get_all_values(behavior, Attrs)],
+    [] =:= [Behaviour] -- Found.
 
 read_library(Mod, Section, Which) ->
     [{Name, lib_function(Mod, Fun)}

--- a/test/erlydtl_lib_test2a.erl
+++ b/test/erlydtl_lib_test2a.erl
@@ -1,0 +1,16 @@
+-module(erlydtl_lib_test2a).
+%% test multiple behaviors (alternative spelling)
+-behavior(erlydtl_lib_test1).
+-behavior(erlydtl_library).
+
+-export([version/0, inventory/1, reverse/1]).
+
+version() -> 1.
+
+inventory(filters) -> [reverse];
+inventory(tags) -> [].
+
+reverse(String) when is_list(String) ->
+    lists:reverse(String);
+reverse(String) when is_binary(String) ->
+    reverse(binary_to_list(String)).

--- a/test/erlydtl_test_defs.erl
+++ b/test/erlydtl_test_defs.erl
@@ -1674,6 +1674,12 @@ all_test_defs() ->
         [{default_libraries, [test2]},
          {libraries, [{test2, erlydtl_lib_test2}]}],
         <<"ytrewQ">>
+       },
+       {"lib with multiple behaviors (alternative spelling)",
+        <<"{{ QWER|reverse }}">>, [{'QWER', "Qwerty"}], [],
+        [{default_libraries, [test2]},
+         {libraries, [{test2, erlydtl_lib_test2a}]}],
+        <<"ytrewQ">>
        }
       ]},
      {"compile time default vars/constants",


### PR DESCRIPTION
Erlang recognizes both spellings `-behavior` and `-behaviour`.
This change allows use of either one in custom tags and filters modules when defining erlydtl_library behavior.

Thanks,
Alex.