### PR TITLE
Be precise about gb_trees struct to avoid problems with simple tuples

### DIFF
--- a/src/erlydtl_runtime.erl
+++ b/src/erlydtl_runtime.erl
@@ -72,7 +72,8 @@ find_value(Key, L) when is_integer(Key), is_list(L) ->
     if Key =< length(L) -> lists:nth(Key, L);
        true -> undefined
     end;
-find_value(Key, {GBSize, GBData}) when is_integer(GBSize) ->
+find_value(_, {0, nil}) -> undefined;
+find_value(Key, {GBSize, {_, _, _, _}=GBData}) when is_integer(GBSize) ->
     case gb_trees:lookup(Key, {GBSize, GBData}) of
         {value, Val} ->
             Val;

--- a/test/erlydtl_test_defs.erl
+++ b/test/erlydtl_test_defs.erl
@@ -136,6 +136,8 @@ all_test_defs() ->
         <<"{{ var1 }}">>, dict:store(var1, "bar", dict:new()), <<"bar">>},
        {"Render variable with missing attribute in dict",
         <<"{{ var1.foo }}">>, [{var1, dict:store(bar, "Othello", dict:new())}], <<"">>},
+       {"Render variable in a two elements tuple",
+        <<"{{ var1.2 }}">>, [{var1,{12,[bar]}}], <<"bar">>},
        {"Render variable in gb_tree",
         <<"{{ var1 }}">>, gb_trees:insert(var1, "bar", gb_trees:empty()), <<"bar">>},
        {"Render variable in arity-1 func",


### PR DESCRIPTION
Hello.

Consider I'd like to render a list of tuples like this one: {year, [{month, [day1,day2] }] }
```
1>{ok, T} = erlydtl:compile_template("{{dates}}, {% for y in dates %}{{y.1}} {% for m in y.2 %} {{m.1}} {% endfor %}{% endfor %}", test1).
Compile template: {{dates}}, {% for y in dates %}{...
{ok,test1}
2>T:render([{dates,[{2015,[{8,[27,30]}]}]}]).
** exception error: no function clause matching gb_trees:lookup_1(1,[{8,[27,30]}]) (gb_trees.erl, line 201)
     in function  erlydtl_runtime:find_value/2 (src/erlydtl_runtime.erl, line 76)
     in call from erlydtl_runtime:fetch_value/4 (src/erlydtl_runtime.erl, line 142)
     in call from test1:'-render_internal/2-fun-1-'/3 (, line 1173)
     in call from lists:mapfoldl/3 (lists.erl, line 1352)
     in call from erlydtl_runtime:forloop/4 (src/erlydtl_runtime.erl, line 399)
     in call from test1:render_internal/2 (, line 1384)
     in call from test1:render/2 (, line 495)
```
The tuple is mistaken for a gb_tree. The patch describes gb_tree more accurate (a tuple of int and 4 element or 'nil'). 
The result would be 
```
1> {ok, T} = erlydtl:compile_template("{{dates}}, {% for y in dates %}{{y.1}} {% for m in y.2 %} {{m.1}} {% endfor %}{% endfor %}", test1).
Compile template: {{dates}}, {% for y in dates %}{...
test1: Warning: Compiled template not saved (need out_dir option)
{ok,test1}
 2> T:render([{dates,[{2015,[{8,[27,30]}]}]}]).
{ok,[[<<"{2015,[{8,[27,30]}]}">>],
     <<", ">>,
     [["2015",<<" ">>,[[<<" ">>,"8",<<" ">>]]]]]}
```
I'm not really familiar with gb_trees, so please review the patch before merging.

UPD: the post is updated by @seriyps notice: i posted the wrong stacktrace.