### PR TITLE
Update a link to Django documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Project homepage: <https://github.com/erlydtl/erlydtl/wiki>
 
 ErlyDTL implements the Django Template Language as documented for
 version *1.6*, here:
-<http://docs.djangoproject.com/en/1.6/ref/templates/builtins/>
+<https://django.readthedocs.org/en/1.6.x/ref/templates/builtins.html>
 
 Despite our best efforts to be completely compatible with the Django
 Template Languge, there are still a few


### PR DESCRIPTION
Documentation for unsupported versions of Django has been withdrawn from
the official Django website, but it is available on Read the Docs.

Fixes #235.

[A relevant django-developers discussion](https://groups.google.com/d/msg/django-developers/5TsL3MED5W8/YBtNry6hAwAJ) is available.