### PR TITLE
Support tuple wrapped list keyfind lookups

### DIFF
--- a/src/erlydtl_runtime.erl
+++ b/src/erlydtl_runtime.erl
@@ -81,6 +81,8 @@ find_value(Key, {GBSize, GBData}) when is_integer(GBSize) ->
     end;
 find_value(Key, Tuple) when is_tuple(Tuple) ->
     case element(1, Tuple) of
+        L when is_list(L) andalso size(Tuple) =:= 1 ->
+            find_value(Key, L);
         dict ->
             case dict:find(Key, Tuple) of
                 {ok, Val} ->

--- a/test/erlydtl_test_defs.erl
+++ b/test/erlydtl_test_defs.erl
@@ -132,6 +132,8 @@ all_test_defs() ->
         <<"I also enjoy {{ var1.game }}">>, [{var1, [{"game", "Parcheesi"}]}], <<"I also enjoy Parcheesi">>},
        {"Render variable with binary-key attribute",
         <<"I also enjoy {{ var1.game }}">>, [{var1, [{<<"game">>, "Parcheesi"}]}], <<"I also enjoy Parcheesi">>},
+       {"Render variable with tuple wrapped proplist",
+        <<"I also enjoy {{ var1.game }}">>, [{var1, {[{<<"game">>, "Parcheesi"}]}}], <<"I also enjoy Parcheesi">>},
        {"Render variable in dict",
         <<"{{ var1 }}">>, dict:store(var1, "bar", dict:new()), <<"bar">>},
        {"Render variable with missing attribute in dict",


### PR DESCRIPTION
This enables key lookup on tuple-wrapped proplists.

<strike>
```
Template:render(Data, [{tuple_wrapped_proplists, true}]).
```
</strike>

This is useful for data decoded from JSON or prepared for encoding to JSON with [jiffy](https://github.com/davisp/jiffy)

Submitting this PR now without docs or tests to verify it's acceptable before I put more work into it.

<strike>Also, should this be added as a `compile` option as well?</strike>

---
TODO
* [ ] <strike>Docs</strike>
* [x] Tests