### PR TITLE
fix for Failed to extract name from erlydtl.app.src

### DIFF
--- a/src/erlydtl.app.src.script
+++ b/src/erlydtl.app.src.script
@@ -5,10 +5,10 @@ ExtraApps = case application:get_key(syntax_tools, vsn) of
                 _ -> []
             end,
 
-{application, erlydtl,
+[{application, erlydtl,
  [{description, "Django Template Language for Erlang"},
   {vsn, git},
   {modules, []},
   {applications, [kernel, stdlib, compiler, syntax_tools|ExtraApps]},
   {registered, []}
- ]}.
+ ]}].


### PR DESCRIPTION
expected return value is a list, so that small fix solves issue #231  and probably #251 