### PR TITLE
compatibility with OTP 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: erlang
 sudo: false
 otp_release:
 # Test on all the latest releases for the major versions supported as specified by the `require_otp_vsn` in rebar.config
+   - 21.0
    - 20.0
    - 19.3
    - 18.0

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 %% accept R15B02.., any R16B except R16B03
 %% also accept OTP v17, altough it may not work properly on that release yet..
-{require_otp_vsn, "R15B0[^1]|R16B$|R16B[^0]|R16B0[^3]|R16B03-1|17|18|19|20"}.
+{require_otp_vsn, "R15B0[^1]|R16B$|R16B[^0]|R16B0[^3]|R16B03-1|17|18|19|20|21"}.
 
 {erl_opts, [debug_info]}.
 {yrl_opts, [{includefile, "include/erlydtl_preparser.hrl"}]}.

--- a/src/erlydtl_beam_compiler.erl
+++ b/src/erlydtl_beam_compiler.erl
@@ -861,8 +861,9 @@ blocktrans_ast(Args, Contents, PluralContents, TreeWalker) ->
                               Body ->
                                   {ok, DjangoParseTree} = do_parse_template(Body, TreeWalkerAcc#treewalker.context),
                                   {{BodyAst, BodyInfo}, BodyTreeWalker} = body_ast(DjangoParseTree, TreeWalkerAcc),
+                                  Clause = erl_syntax:clause([erl_syntax:abstract(Locale)], none, [BodyAst]),
                                   {merge_info(BodyInfo, AstInfoAcc), BodyTreeWalker,
-                                   [?Q("_@Locale@ -> _@BodyAst")|ClauseAcc]}
+                                  [Clause | ClauseAcc]}
                           end
                   end,
                   {MergedInfo, TreeWalker3, []}, TLocales),
@@ -975,14 +976,15 @@ compiletime_trans_ast(TFun, Text, LContext,
                         }=TreeWalker) ->
     ClAst = lists:foldl(
               fun(Locale, ClausesAcc) ->
-                      [?Q("_@Locale@ -> _@translated",
-                          [{translated, case TFun(Text, phrase_locale(Locale, LContext)) of
-                                            default -> string_ast(Text, Context);
-                                            Translated -> string_ast(Translated, Context)
-                                        end}])
-                       |ClausesAcc]
+                      BodyAst = case TFun(Text, phrase_locale(Locale, LContext)) of
+                                    default -> string_ast(Text, Context);
+                                    Translated -> string_ast(Translated, Context)
+                                end,
+                      Clause = erl_syntax:clause([erl_syntax:abstract(Locale)], none, [BodyAst]),
+                      [Clause | ClausesAcc]
               end,
               [], TLocales),
+
     {{?Q(["case _CurrentLocale of",
           "  _@_ClAst -> _;",
           " _ -> _@string",

--- a/src/erlydtl_filters.erl
+++ b/src/erlydtl_filters.erl
@@ -355,10 +355,10 @@ floatformat(_, _) -> "".
 floatformat_io(Number, []) ->
     floatformat_io(Number, -1);
 floatformat_io(Number, 0) ->
-    hd(io_lib:format("~B", [erlang:round(Number)]));
+    lists:flatten(io_lib:format("~B", [erlang:round(Number)]));
 floatformat_io(Number, Precision) when Precision > 0 ->
-    hd(io_lib:format("~.*f",[Precision, Number]));
-floatformat_io(Number, Precision) when Precision < 0 ->   
+    lists:flatten(io_lib:format("~.*f",[Precision, Number]));
+floatformat_io(Number, Precision) when Precision < 0 ->
     Round = erlang:round(Number),
     RoundPrecision = round(Number, -Precision),
     if RoundPrecision == Round ->
@@ -590,11 +590,12 @@ stringformat(Input, Conversion) when is_binary(Conversion) ->
     stringformat(Input, unicode:characters_to_list(Conversion));
 stringformat(Input, Conversion) ->
     ParsedConversion = re:replace(Conversion, "([\-#\+ ]?)([0-9\*]+)?(\.?)([0-9]?)([diouxXeEfFgGcrs])", "\\1 ,\\2 ,\\3 ,\\4 ,\\5 ", [{return,list}]),
+
     ?debugFmt("ParsedConversion: ~p~n", [ParsedConversion]),
     ParsedConversion1 = lists:map(fun(X) -> string:strip(X) end, string:tokens(ParsedConversion, ",")),
     [ConversionFlag, MinFieldWidth, Precision, PrecisionLength, ConversionType] = ParsedConversion1,
     ?debugFmt("ConversionFlag, MinFieldWidth, Precision, PrecisionLength, ConversionType: ~p, ~p, ~p, ~p, ~p ~n", [ConversionFlag, cast_to_integer(MinFieldWidth), Precision, cast_to_integer(PrecisionLength), ConversionType]),
-    [String] = stringformat_io(Input, Conversion, ConversionFlag, cast_to_integer(MinFieldWidth), Precision, cast_to_integer(PrecisionLength), ConversionType),
+    String = stringformat_io(Input, Conversion, ConversionFlag, cast_to_integer(MinFieldWidth), Precision, cast_to_integer(PrecisionLength), ConversionType),
     lists:flatten(String).
 
 %% @doc
@@ -640,6 +641,7 @@ stringformat_io(Input, Conversion, _ConversionFlag, _MinFieldWidth,
     io_lib:format(Format, [cast_to_float(Input)]);
 stringformat_io(Input, Conversion, _ConversionFlag, _MinFieldWidth,
     [], [], "d")->
+
     %?debugMsg("plain d"),
     %Conversion = [ConversionFlag, MinFieldWidth, Precision, PrecisionLength, ConversionType],
     Format = "~" ++ re:replace(Conversion, "d", "B", [{return, list}] ),


### PR DESCRIPTION
Some filters worked incorrectly due to change in `io_lib:format` result - it used to return `["string"]`, now it is just `"string"`.