### PR TITLE
Ensure modules are loaded when checking function_exported

### DIFF
--- a/src/erlydtl_runtime.erl
+++ b/src/erlydtl_runtime.erl
@@ -472,6 +472,7 @@ read_file(Module, Function, DocRoot, FileName, ReaderOptions) ->
             throw({read_file, AbsName, Reason})
     end.
 read_file_internal(Module, Function, FileName, ReaderOptions) ->
+    _ = code:ensure_loaded(Module),
     case erlang:function_exported(Module, Function,1) of
         true ->
             Module:Function(FileName);


### PR DESCRIPTION
In the read_file_internal function, erlydtl checks to see if the specified reader Module:Function is exported; however if the Module in question hasn't been loaded by the code server, this returns false. This change tries to load the Module into the code server just before checking if the function has been exported.