### PR TITLE
Add support for iterating maps

### DIFF
--- a/src/erlydtl_runtime.erl
+++ b/src/erlydtl_runtime.erl
@@ -374,6 +374,8 @@ to_list(Value, true) ->
     lists:reverse(to_list(Value, false));
 to_list(Value, false) when is_list(Value) ->
     Value;
+to_list(Value, false) when is_map(Value) ->
+    maps:to_list(Value);
 to_list(Value, false) when is_tuple(Value) ->
     case element(1, Value) of
         'Elixir.Ecto.Associations.HasMany' ->

--- a/test/erlydtl_test_defs.erl
+++ b/test/erlydtl_test_defs.erl
@@ -2133,6 +2133,12 @@ setup("for") ->
 setup("for_list") ->
     RenderVars = [{fruit_list, [["apple", "apples", "$1"], ["banana", "bananas", "$2"], ["coconut", "coconuts", "$500"]]}],
     {ok, RenderVars};
+setup("for_map") ->
+    Links = #{"Amazon" => "http://amazon.com",
+              "Google" => "http://google.com",
+              "Microsoft" => "http://microsoft.com"},
+    RenderVars = [{link_list, Links}],
+    {ok, RenderVars};
 setup("for_tuple") ->
     RenderVars = [{fruit_list, [{"apple", "apples"}, {"banana", "bananas"}, {"coconut", "coconuts"}]}],
     {ok, RenderVars};

--- a/test/files/expect/for_map
+++ b/test/files/expect/for_map
@@ -1,0 +1,13 @@
+before
+
+<ul>
+
+	<li><a href="http://amazon.com">Amazon</a></li>
+
+	<li><a href="http://google.com">Google</a></li>
+
+	<li><a href="http://microsoft.com">Microsoft</a></li>
+
+</ul>
+
+after

--- a/test/files/input/for_map
+++ b/test/files/input/for_map
@@ -1,0 +1,9 @@
+before
+
+<ul>
+{% for iterator in link_list %}
+	<li><a href="{{ iterator.url }}">{{ iterator.name }}</a></li>
+{% endfor %}
+</ul>
+
+after


### PR DESCRIPTION
Allows iterating over maps by using

    {% for key, value in map %}
    {{ key }}: {{ value }}
    {% endfor %}