### PR TITLE
Use the new way of retrieving stacktraces

### DIFF
--- a/include/erlydtl_preparser.hrl
+++ b/include/erlydtl_preparser.hrl
@@ -72,9 +72,8 @@ return_state() ->
 
 yeccpars0(Tokens, Tzr, State, States, Vstack) ->
     try yeccpars1(Tokens, Tzr, State, States, Vstack)
-    catch 
-        error: Error ->
-            Stacktrace = erlang:get_stacktrace(),
+    catch
+        error: Error:Stacktrace ->
             try yecc_error_type(Error, Stacktrace) of
                 Desc ->
                     erlang:raise(error, {yecc_bug, ?CODE_VERSION, Desc},
@@ -104,11 +103,11 @@ yecc_error_type(function_clause, [{?MODULE,F,ArityOrArgs,_} | _]) ->
 		Else ->
 		    Else
 	    end
-	catch 
+	catch
 	    throw: return_state ->
 		{ok, STATE}
 	end).
-    
+
 yeccpars1([Token | Tokens], Tzr, State, States, Vstack) ->
     ?checkparse(
        yeccpars2(State, element(1, Token), States, Vstack, Token, Tokens, Tzr),

--- a/src/i18n/sources_parser.erl
+++ b/src/i18n/sources_parser.erl
@@ -124,9 +124,9 @@ parse_content(Path,Content)->
             try process_ast(Path, Data) of
                 {ok, Result} -> Result
             catch
-                Error:Reason ->
+                Error:Reason:Stacktrace ->
                     io:format("~s: Template processing failed~nData: ~p~n", [Path, Data]),
-                    erlang:raise(Error, Reason, erlang:get_stacktrace())
+                    erlang:raise(Error, Reason, Stacktrace)
             end;
         Error ->
             ?bail("Template parsing failed for template ~s, cause ~p~n", [Path, Error])


### PR DESCRIPTION
erlang:get_stacktrace() is deprecated so use the new way (http://erlang.org/doc/man/erlang.html#get_stacktrace-0)

Tested with existing test suite and everything is green