### PR TITLE
Fix stacktrace warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ otp_release:
    - 18.0
    - 17.4
    - R16B03-1
-#  - R15B03-1 not available on travis
-   - R15B03
 
-script: 
+script:
   - "[ ! -d deps/merl ] || make -C deps/merl && make check"
 
 notifications:

--- a/include/erlydtl_ext.hrl
+++ b/include/erlydtl_ext.hrl
@@ -6,12 +6,12 @@
          }).
 
 -record(dtl_context, {
-          local_scopes = [], 
-          block_dict = dict:new(), 
+          local_scopes = [],
+          block_dict = dict:new(),
           trans_fun = none,
           trans_locales = [],
           auto_escape = [off],
-          doc_root = "", 
+          doc_root = "",
           parse_trail = [],
           vars = [],
           const = [],
@@ -56,7 +56,7 @@
           safe = false,
           extension = undefined,
           context
-         }).    
+         }).
 
 -record(scanner_state, {
           template=[],
@@ -76,3 +76,9 @@
 -define(LOG_INFO(Fmt, Args, Ctx), erlydtl_compiler_utils:print(?V_INFO, Fmt, Args, Ctx)).
 -define(LOG_DEBUG(Fmt, Args, Ctx), erlydtl_compiler_utils:print(?V_DEBUG, Fmt, Args, Ctx)).
 -define(LOG_TRACE(Fmt, Args, Ctx), erlydtl_compiler_utils:print(?V_TRACE, Fmt, Args, Ctx)).
+
+-ifndef(OTP_RELEASE).
+-define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(), ).
+-else.
+-define(WITH_STACKTRACE(T, R, S), T:R:S ->).
+-endif.

--- a/include/erlydtl_preparser.hrl
+++ b/include/erlydtl_preparser.hrl
@@ -31,6 +31,8 @@
 
 -export([parse/1, parse_and_scan/1, format_error/1, resume/1]).
 
+-include("erlydtl_ext.hrl").
+
 -type yecc_ret() :: {'error', _, _} | {'ok', _}.
 
 -spec parse(Tokens :: list()) -> yecc_ret().
@@ -72,9 +74,8 @@ return_state() ->
 
 yeccpars0(Tokens, Tzr, State, States, Vstack) ->
     try yeccpars1(Tokens, Tzr, State, States, Vstack)
-    catch 
-        error: Error ->
-            Stacktrace = erlang:get_stacktrace(),
+    catch
+        ?WITH_STACKTRACE(error, Error, Stacktrace)
             try yecc_error_type(Error, Stacktrace) of
                 Desc ->
                     erlang:raise(error, {yecc_bug, ?CODE_VERSION, Desc},
@@ -104,11 +105,11 @@ yecc_error_type(function_clause, [{?MODULE,F,ArityOrArgs,_} | _]) ->
 		Else ->
 		    Else
 	    end
-	catch 
+	catch
 	    throw: return_state ->
 		{ok, STATE}
 	end).
-    
+
 yeccpars1([Token | Tokens], Tzr, State, States, Vstack) ->
     ?checkparse(
        yeccpars2(State, element(1, Token), States, Vstack, Token, Tokens, Tzr),

--- a/src/i18n/sources_parser.erl
+++ b/src/i18n/sources_parser.erl
@@ -124,9 +124,9 @@ parse_content(Path,Content)->
             try process_ast(Path, Data) of
                 {ok, Result} -> Result
             catch
-                Error:Reason ->
+                ?WITH_STACKTRACE(Error, Reason, Stacktrace)
                     io:format("~s: Template processing failed~nData: ~p~n", [Path, Data]),
-                    erlang:raise(Error, Reason, erlang:get_stacktrace())
+                    erlang:raise(Error, Reason, Stacktrace)
             end;
         Error ->
             ?bail("Template parsing failed for template ~s, cause ~p~n", [Path, Error])


### PR DESCRIPTION
I'm not 100% sure you want to include the erlydtl_ext.hrl in erlydtl_ext.hrl but it was either that, have a separate hrl-file or duplicated code. Think this is the least evil thing :-).