### PR TITLE
Hex wrong vsn and support OTP 23

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 %% accept R15B02.., any R16B except R16B03
 %% also accept OTP v17, altough it may not work properly on that release yet..
-{require_otp_vsn, "R16B$|R16B[^0]|R16B0[^3]|R16B03-1|17|18|19|20|21|22"}.
+{require_otp_vsn, "R16B$|R16B[^0]|R16B0[^3]|R16B03-1|17|18|19|20|21|22|23"}.
 
 {erl_opts, [debug_info]}.
 {yrl_opts, [{includefile, "include/erlydtl_preparser.hrl"}]}.

--- a/src/erlydtl.app.src.script
+++ b/src/erlydtl.app.src.script
@@ -4,11 +4,7 @@ ExtraApps = case application:get_key(syntax_tools, vsn) of
                 {ok, Vsn} when "1.7" > Vsn -> [merl];
                 _ -> []
             end,
-
-[{application, erlydtl,
- [{description, "Django Template Language for Erlang"},
-  {vsn, git},
-  {modules, []},
-  {applications, [kernel, stdlib, compiler, syntax_tools|ExtraApps]},
-  {registered, []}
- ]}].
+Apps = [kernel, stdlib, compiler, syntax_tools | ExtraApps],
+[{application, erlydtl, Spec}] = CONFIG,
+NewSpec = lists:keystore(applications, 1, Spec, {applications, Apps}),
+[{application, erlydtl, NewSpec}].


### PR DESCRIPTION
Because `erlydtl.app.src.script` is modifying the current `erlydtl.app.src` to put `{vsn, git}` this is messing up a lot when we are installing erlydtl from hex (because .git isn't included).

I propose modify only the applications inside of the script file (as I put inside of this PR), and of course, update platforms, I'm using OTP 23 and this is working fine!