### PR TITLE
Fix calls to Gettext nonexisting functions

### DIFF
--- a/src/i18n/po_generator.erl
+++ b/src/i18n/po_generator.erl
@@ -15,11 +15,17 @@
 %%
 %% API Functions
 %%
+-define(LANG_DIR, "lang").
+-define(POFILE, "gettext.po").
 generate_file(Lang,Items, Fuzzy) ->
     Gettext_App_Name = "tmp",
     GtxtDir = ".",
     io:format("Opening po file"),
-    gettext_compile:open_po_file(Gettext_App_Name, GtxtDir, Lang),
+    DefDir = filename:join([GtxtDir, ?LANG_DIR, Gettext_App_Name, Lang]),
+    Fname = filename:join([DefDir, ?POFILE]),
+    filelib:ensure_dir(Fname),
+    {ok,Fd} = file:open(Fname, [write]),
+    put(fd,Fd),
 
     gettext_compile:write_header(),
     io:format("Writing entries~n"),

--- a/src/i18n/po_generator.erl
+++ b/src/i18n/po_generator.erl
@@ -37,9 +37,9 @@ write_entries(Items)->
                 Fi = gettext_compile:fmt_fileinfo(Finfo),
                 io:format(Fd, "~n#: ~s~n", [Fi]),
                 ok = file:write(Fd, "msgid \"\"\n"),
-                gettext_compile:write_pretty(Id),
+                gettext_compile:write_pretty(Id, Fd),
                 ok = file:write(Fd, "msgstr \"\"\n"),
-                gettext_compile:write_pretty(Translation)
+                gettext_compile:write_pretty(Translation, Fd)
         end,
     lists:foreach(F, Items).
 
@@ -49,9 +49,9 @@ write_fuzzy_entries(Items) ->
     F = fun({Id,Translation,_}) ->
                 ok = file:write(Fd, "#, fuzzy\n"),
                 ok = file:write(Fd, "msgid \"\"\n"),
-                gettext_compile:write_pretty(Id),
+                gettext_compile:write_pretty(Id, Fd),
                 ok = file:write(Fd, "msgstr \"\"\n"),
-                gettext_compile:write_pretty(Translation),
+                gettext_compile:write_pretty(Translation, Fd),
                 ok = file:write(Fd, "\n")
         end,
     lists:foreach(F, Items).

--- a/src/i18n/po_generator.erl
+++ b/src/i18n/po_generator.erl
@@ -32,7 +32,7 @@ generate_file(Lang,Items, Fuzzy) ->
     write_entries(Items),
     io:format("Writing fuzzy entries~n"),
     write_fuzzy_entries(Fuzzy),
-    gettext_compile:close_file().
+    file:close(Fd).
 
 %%
 %% Local Functions

--- a/src/i18n/po_generator.erl
+++ b/src/i18n/po_generator.erl
@@ -31,10 +31,19 @@ generate_file(Lang,Items, Fuzzy) ->
 %%
 %% Local Functions
 %%
+
+to_list(A) when is_atom(A)    -> atom_to_list(A);
+to_list(I) when is_integer(I) -> integer_to_list(I);
+to_list(B) when is_binary(B)  -> binary_to_list(B);
+to_list(L) when is_list(L)    -> L.
+
 write_entries(Items)->
     Fd = get(fd),
     F = fun({Id,Translation,Finfo}) ->
-                Fi = gettext_compile:fmt_fileinfo(Finfo),
+                Fun = fun({Fname,LineNo}, Acc) ->
+                    Fname ++ ":" ++ to_list(LineNo) ++ [$\s|Acc]
+                end,
+                Fi = lists:foldr(Fun,[],Finfo),
                 io:format(Fd, "~n#: ~s~n", [Fi]),
                 ok = file:write(Fd, "msgid \"\"\n"),
                 gettext_compile:write_pretty(Id, Fd),


### PR DESCRIPTION
Hello!
I've checked @etnt 's [gettext](https://github.com/etnt/gettext)  history and it looks like these functions were never exported (or were exported prior to converting to Git). So I've replaced them with the code they supposed to call instead.