### PR TITLE
Update OTP 29

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,8 @@ jobs:
     name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
     strategy:
       matrix:
-        otp: ['26.2', '27.3', '28.0']
-        rebar3: ['3.24', '3.25']
+        otp: ['26.2', '27.3', '28.4', '29.0']
+        rebar3: ['3.25', '3.26', '3.27']
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1.20.4

--- a/rebar.config
+++ b/rebar.config
@@ -22,5 +22,5 @@
 
 {dialyzer,
  [
-  {warnings, [underspecs, unmatched_returns, race_conditions, error_handling]}
+  {warnings, [underspecs, unmatched_returns, error_handling]}
  ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 %% -*- mode: erlang -*-
 
-{require_otp_vsn, "18"}.
+{require_otp_vsn, "18"}. % read by rebar2
+{minimum_otp_vsn, "18"}. % read by rebar3
 
 {erl_opts, [debug_info]}.
 {yrl_opts, [{includefile, "include/erlydtl_preparser.hrl"}]}.

--- a/src/erlydtl_beam_compiler.erl
+++ b/src/erlydtl_beam_compiler.erl
@@ -327,13 +327,13 @@ is_up_to_date(CheckSum, Context) ->
     Module = Context#dtl_context.module,
     {M, F} = Context#dtl_context.reader,
     ReaderOptions = Context#dtl_context.reader_options,
-    case catch Module:source() of
+    try Module:source() of
         {_, CheckSum} ->
-            case catch Module:dependencies() of
+            try Module:dependencies() of
                 L when is_list(L) ->
                     RecompileList = lists:foldl(
                                       fun ({XFile, XCheckSum}, Acc) ->
-                                              case catch erlydtl_runtime:read_file_internal(M, F, XFile, ReaderOptions) of
+                                              try erlydtl_runtime:read_file_internal(M, F, XFile, ReaderOptions) of
                                                   {ok, Data} ->
                                                       case binary_to_list(erlang:md5(Data)) of
                                                           XCheckSum ->
@@ -343,6 +343,8 @@ is_up_to_date(CheckSum, Context) ->
                                                       end;
                                                   _ ->
                                                       [recompile | Acc]
+                                              catch
+                                                 _:_ -> [recompile | Acc]
                                               end
                                       end, [], L),
                     case RecompileList of
@@ -351,9 +353,11 @@ is_up_to_date(CheckSum, Context) ->
                     end;
                 _ ->
                     false
+            catch _:_ -> false
             end;
         _ ->
             false
+    catch _:_ -> false
     end.
 
 

--- a/src/erlydtl_compiler.erl
+++ b/src/erlydtl_compiler.erl
@@ -368,11 +368,12 @@ is_up_to_date(CheckSum, Context) ->
 parse_file(File, Context) ->
     {M, F} = Context#dtl_context.reader,
     ReaderOptions = Context#dtl_context.reader_options,
-    case catch erlydtl_runtime:read_file_internal(M, F, File, ReaderOptions) of
+    try erlydtl_runtime:read_file_internal(M, F, File, ReaderOptions) of
         {ok, Data} ->
             parse_template(Data, Context);
         {error, Reason} ->
             {error, {read_file, File, Reason}}
+    catch _:Err -> {error, Err}
     end.
 
 parse_template(Data, Context) ->

--- a/test/erlydtl_translation_tests.erl
+++ b/test/erlydtl_translation_tests.erl
@@ -8,7 +8,9 @@ all_sources_parser_test_() ->
 
 test_fun({Name, Template, Variables, Options, Output}) ->
     {Name, fun () ->
-                   Tokens = (catch compile_and_render(Template, Variables, Options)),
+                   Tokens = try compile_and_render(Template, Variables, Options)
+                            catch _:_ -> error
+                            end,
                    ?assertMatch(Output, Tokens)
            end}.
 

--- a/test/sources_parser_tests.erl
+++ b/test/sources_parser_tests.erl
@@ -9,7 +9,9 @@ all_sources_parser_test_() ->
 
 test_fun({Name, Content, Output}) ->
     {Name, fun () ->
-                   Tokens = (catch sources_parser:process_content("dummy_path", Content)),
+                   Tokens = try sources_parser:process_content("dummy_path", Content)
+                            catch _:_ -> error
+                            end,
                    ?assertMatch(Output, Tokens)
            end}.
 
@@ -95,9 +97,10 @@ test_unparser_fun({Name, Tpl}) ->
                            case erlydtl_compiler:do_parse_template(
                                   Unparsed, #dtl_context{}) of
                                {ok, DptU} ->
-                                   case catch compare_tree(Dpt, DptU) of
-                                       ok -> ok;
-                                       Err -> throw({compare_failed, Err, {test_ast, Dpt}, {unparsed, {source, Unparsed}, {ast, DptU}}})
+                                   try compare_tree(Dpt, DptU) of
+                                       ok -> ok
+                                   catch
+                                       _:Err -> throw({compare_failed, Err, {test_ast, Dpt}, {unparsed, {source, Unparsed}, {ast, DptU}}})
                                    end;
                                Err ->
                                    throw({unparsed_source, Err})


### PR DESCRIPTION
This PR includes several small changes to update ErlyDTL to newer tools:

- Solve warnings when compiling ErlyDTL with Erlang/OTP 29 (right now it's 29.0-rc2).
- Updates some versions in the workflow matrix
- Adds `minimum_otp_vsn`, which is read by rebar3
- Removes `race_conditions` option that newer dialyzer does not understand and breaks dialyzer

If you consider any of those commits is irrelevant or unnecessary, please comment and I'll remove it from the PR

Thanks!
